### PR TITLE
Don't link against crypt on Linux

### DIFF
--- a/pdfmp/build.gradle.kts
+++ b/pdfmp/build.gradle.kts
@@ -65,6 +65,7 @@ fun KotlinNativeTarget.setUpPdfiumCinterop() {
 private fun KotlinNativeTarget.setupSharedLib() {
     val androidLib = androidArchMap[name]
     val pdfiumPath = androidLib ?: name
+    val targetName = name
 
     binaries {
         sharedLib {
@@ -81,7 +82,11 @@ private fun KotlinNativeTarget.setupSharedLib() {
         val binariesModuleDir = project(":pdfium-binaries").projectDir
         linkerOpts.add("-L$binariesModuleDir/binaries/$pdfiumPath")
         linkerOpts.add("-lpdfium")
-        if (name.contains("linux")) linkerOpts.add("-lcrypt")
+
+        // Without this we'd link against libcrypt.so.1 unnecessarily and that's
+        // not even available in a flatpak.
+        // See https://youtrack.jetbrains.com/projects/KT/issues/KT-55643
+        if (targetName.contains("linux")) linkerOpts.add("-Wl,--as-needed")
     }
 
     binaries {


### PR DESCRIPTION
At least the unit tests run successfully without linking against crypt. This dependency seems to be not needed? It also makes flatpak builds more complicated because there is no libcrypt.so.1 and you need to manually integrate it.