### PR TITLE
Allow customizing JNI lib loading

### DIFF
--- a/pdfmp/src/jvmMain/kotlin/com/dshatz/pdfmp/InitLib.jvm.kt
+++ b/pdfmp/src/jvmMain/kotlin/com/dshatz/pdfmp/InitLib.jvm.kt
@@ -9,10 +9,13 @@ import kotlin.use
 actual class InitLib {
     private val osName = System.getProperty("os.name").lowercase(Locale.ENGLISH)
     private val osArch = System.getProperty("os.arch").lowercase(Locale.ENGLISH)
+    
+    var overrideLoadLibrary: (name: String) -> Unit = ::loadLibraryFromJar
+    
     actual fun init() {
         try {
-            loadLibraryFromJar("pdfium")
-            loadLibraryFromJar("pdfmp")
+            overrideLoadLibrary("pdfium")
+            overrideLoadLibrary("pdfmp")
             PDFBridge.initNative()
         } catch (e: UnsatisfiedLinkError) {
             e("Failed to load native library", e)
@@ -20,6 +23,16 @@ actual class InitLib {
     }
 
     private fun loadLibraryFromJar(baseName: String) {
+        // Detect Flatpak sandbox
+        if ((osName.contains("nux") || osName.contains("nix")) && File("/.flatpak-info").exists()) {
+            try {
+                System.loadLibrary(baseName)
+                return
+            } catch (e: Throwable) {
+                // Ignore
+            }
+        }
+
         val (platformDir, extension, prefix) = getPlatformDetails()
 
         val fileName = "${prefix}${baseName}.${extension}"

--- a/pdfmp/src/jvmMain/kotlin/com/dshatz/pdfmp/InitLib.jvm.kt
+++ b/pdfmp/src/jvmMain/kotlin/com/dshatz/pdfmp/InitLib.jvm.kt
@@ -10,12 +10,10 @@ actual class InitLib {
     private val osName = System.getProperty("os.name").lowercase(Locale.ENGLISH)
     private val osArch = System.getProperty("os.arch").lowercase(Locale.ENGLISH)
     
-    var overrideLoadLibrary: (name: String) -> Unit = ::loadLibraryFromJar
-    
     actual fun init() {
         try {
-            overrideLoadLibrary("pdfium")
-            overrideLoadLibrary("pdfmp")
+            overrideLoadLibrary?.invoke("pdfium") ?: loadLibraryFromJar("pdfium")
+            overrideLoadLibrary?.invoke("pdfmp") ?: loadLibraryFromJar("pdfmp")
             PDFBridge.initNative()
         } catch (e: UnsatisfiedLinkError) {
             e("Failed to load native library", e)
@@ -23,16 +21,6 @@ actual class InitLib {
     }
 
     private fun loadLibraryFromJar(baseName: String) {
-        // Detect Flatpak sandbox
-        if ((osName.contains("nux") || osName.contains("nix")) && File("/.flatpak-info").exists()) {
-            try {
-                System.loadLibrary(baseName)
-                return
-            } catch (e: Throwable) {
-                // Ignore
-            }
-        }
-
         val (platformDir, extension, prefix) = getPlatformDetails()
 
         val fileName = "${prefix}${baseName}.${extension}"
@@ -81,5 +69,9 @@ actual class InitLib {
         }
 
         throw UnsupportedOperationException("Unsupported OS/Arch: $osName / $osArch")
+    }
+    
+    companion object {
+        var overrideLoadLibrary: ((name: String) -> Unit)? = null
     }
 }


### PR DESCRIPTION
When building Flatpaks via Nucleus, the native libs are not part of the resources, but instead live pre-extracted in a libs/resources folder, so `System.loadLibrary()` should be used directly. For even more flexibility this just allows fully customizing the loading process.

This also needs to be combined with #46 for the best out of the box Nucleus Flatpak experience.