### PR TITLE
Fix viewport buffer lifecycle: use-after-dispose race and ignored allocation failure

### DIFF
--- a/pdfmp-compose/src/commonMain/kotlin/com/dshatz/pdfmp/compose/PdfView.kt
+++ b/pdfmp-compose/src/commonMain/kotlin/com/dshatz/pdfmp/compose/PdfView.kt
@@ -105,11 +105,17 @@ private fun PdfViewport(
         delay(100)
         state.renderViewport(transforms)?.let {
             val (response, buffer) = it
+            val previous = value
             value = CurrentImage(
                 transforms,
                 response.transforms,
                 buffer
             )
+            // Release the replaced image's buffer so the pool can dispose retired buffers.
+            // Skip when the pool handed back the same buffer (reuse path).
+            if (previous != null && previous.buffer !== buffer) {
+                previous.free()
+            }
         }
     }
 

--- a/pdfmp-compose/src/commonMain/kotlin/com/dshatz/pdfmp/compose/state/PdfState.kt
+++ b/pdfmp-compose/src/commonMain/kotlin/com/dshatz/pdfmp/compose/state/PdfState.kt
@@ -16,6 +16,7 @@ import com.dshatz.pdfmp.model.PageTransform
 import com.dshatz.pdfmp.model.RenderRequest
 import com.dshatz.pdfmp.model.RenderResponse
 import com.dshatz.pdfmp.source.PdfSource
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -341,46 +342,66 @@ data class PdfState(
         // Otherwise native will receive 0x0 size and crash.
         if (transforms.isEmpty()) return null
 
-        val buffer = bufferPool.getBufferViewport(transforms)
-        return withContext(Dispatchers.IO) {
-            buffer.withAddress {
-                val response = renderer.render(
-                    RenderRequest(
-                        transforms,
-                        pageSpacing,
-                        topOffset,
-                        buffer.dimensions.withAddress(it),
+        // Buffer acquisition and address access can fail (allocation failure, disposed buffer).
+        // Contain those like render failures — set the error state instead of letting the
+        // exception escape the render coroutine (on Kotlin/Native an uncaught worker exception
+        // kills the process).
+        return try {
+            val buffer = bufferPool.getBufferViewport(transforms)
+            withContext(Dispatchers.IO) {
+                buffer.withAddress {
+                    val response = renderer.render(
+                        RenderRequest(
+                            transforms,
+                            pageSpacing,
+                            topOffset,
+                            buffer.dimensions.withAddress(it),
+                        )
                     )
-                )
-                response.map { resp ->
-                    resp to buffer
-                }.onFailure { error ->
-                    this@PdfState.error.value = error
-                    e("Failed to render viewport", error)
-                }.getOrNull()
+                    response.map { resp ->
+                        resp to buffer
+                    }.onFailure { error ->
+                        this@PdfState.error.value = error
+                        e("Failed to render viewport", error)
+                    }.getOrNull()
+                }
             }
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (t: Throwable) {
+            this@PdfState.error.value = t
+            e("Failed to prepare viewport buffer", t)
+            null
         }
     }
 
     internal suspend fun renderFullPage(transform: PageTransform): Pair<RenderResponse, ConsumerBuffer>? {
-        val buffer = bufferPool.getBufferPage(transform)
-        return withContext(Dispatchers.IO) {
-            buffer.withAddress {
-                val response = renderer.render(
-                    RenderRequest(
-                        listOf(transform),
-                        0,
-                        0,
-                        buffer.dimensions.withAddress(it)
+        return try {
+            val buffer = bufferPool.getBufferPage(transform)
+            withContext(Dispatchers.IO) {
+                buffer.withAddress {
+                    val response = renderer.render(
+                        RenderRequest(
+                            listOf(transform),
+                            0,
+                            0,
+                            buffer.dimensions.withAddress(it)
+                        )
                     )
-                )
-                response.map { resp ->
-                    resp to buffer
-                }.onFailure { error ->
-                    this@PdfState.error.value = error
-                    e("Failed to render pages", error)
-                }.getOrNull()
+                    response.map { resp ->
+                        resp to buffer
+                    }.onFailure { error ->
+                        this@PdfState.error.value = error
+                        e("Failed to render pages", error)
+                    }.getOrNull()
+                }
             }
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (t: Throwable) {
+            this@PdfState.error.value = t
+            e("Failed to prepare page buffer", t)
+            null
         }
     }
 

--- a/pdfmp/src/consumerMain/kotlin/com/dshatz/pdfmp/ConsumerBufferPool.kt
+++ b/pdfmp/src/consumerMain/kotlin/com/dshatz/pdfmp/ConsumerBufferPool.kt
@@ -9,6 +9,14 @@ class ConsumerBufferPool {
     internal val buffers: LinkedHashSet<ConsumerBuffer> = linkedSetOf()
     internal var bufferViewport: ConsumerBuffer? = null
 
+    /**
+     * Viewport buffers replaced while still in use. A previous render coroutine may sit between
+     * getBufferViewport() and withAddress(), and the currently displayed image references the
+     * buffer's pixels zero-copy (extractSubset) — disposing inline frees memory under both.
+     * Retired buffers are disposed on a later request, once their consumer has freed them.
+     */
+    internal val retiredViewportBuffers = mutableListOf<ConsumerBuffer>()
+
     fun getBufferPage(transform: PageTransform): ConsumerBuffer {
         val neededCapacity = transform.bufferSize
         val sliceSize = transform.sliceSize()
@@ -30,6 +38,14 @@ class ConsumerBufferPool {
     }
 
     fun getBufferViewport(transforms: List<PageTransform>): ConsumerBuffer {
+        // Dispose retired buffers whose consumers have released them since the last request.
+        retiredViewportBuffers.removeAll { retired ->
+            if (retired.isFree) {
+                retired.dispose()
+                true
+            } else false
+        }
+
         val (w, h) = transforms.calculateSize()
         val neededCapacity = SizeB(w * h * 4L)
 
@@ -39,14 +55,20 @@ class ConsumerBufferPool {
         if (reuse == null) {
             d("Not reusing viewport buffer. Existing: ${bufferViewport?.dimensions}, required: $w x $h")
         }
-        return reuse ?: run {
-            // Free old viewport buffer memory. We are allocating a new one because the viewport got bigger.
-            bufferViewport?.dispose()
+        val buffer = reuse ?: run {
+            // The viewport got bigger. Never dispose the previous buffer inline — an in-flight
+            // render or the currently displayed image may still hold it. Retire it; it is
+            // disposed above on a later request once its consumer has freed it.
+            bufferViewport?.let { old ->
+                if (old.isFree) old.dispose() else retiredViewportBuffers.add(old)
+            }
             val newBuffer = ConsumerBufferUtil.allocate(neededCapacity, w, h)
             d("Allocated viewport buffer ${neededCapacity.stringMB}")
             this.bufferViewport = newBuffer
             newBuffer
         }
+        buffer.setUnfree()
+        return buffer
     }
 
     internal val totalBufferMemory: SizeB

--- a/pdfmp/src/consumerTest/kotlin/com/dshatz/pdfmp/ConsumerBufferTest.kt
+++ b/pdfmp/src/consumerTest/kotlin/com/dshatz/pdfmp/ConsumerBufferTest.kt
@@ -83,8 +83,13 @@ val consumerBufferTest by testSuite {
             val largerBuffer = pool.getBufferViewport(transformsLarger)
             largerBuffer shouldNotBe buffer
 
-            withClue("Old viewport should have been freed after replacement") {
-                buffer.isFree shouldBe true
+            withClue(
+                "Replaced viewport buffer must be retired, not disposed — an in-flight render " +
+                    "or the displayed image may still hold it. It stays unfree until its " +
+                    "consumer releases it."
+            ) {
+                buffer.isFree shouldBe false
+                pool.retiredViewportBuffers shouldBe listOf(buffer)
             }
         }
     }

--- a/pdfmp/src/nonAndroidConsumerMain/kotlin/com/dshatz/pdfmp/ConsumerBuffer.nonAndroid.kt
+++ b/pdfmp/src/nonAndroidConsumerMain/kotlin/com/dshatz/pdfmp/ConsumerBuffer.nonAndroid.kt
@@ -56,7 +56,12 @@ actual object ConsumerBufferUtil {
         )
 
         val skiaBitmap = Bitmap()
-        skiaBitmap.allocPixels(imageInfo)
+        // allocPixels returns false on failure (invalid/oversized dimensions, out of memory);
+        // ignoring it hands out a pixel-less bitmap whose peekPixels() returns null, and the
+        // consumer then fails later with a misleading "Could not read bitmap buffer address".
+        check(skiaBitmap.allocPixels(imageInfo)) {
+            "Failed to allocate a $width x $height pixel buffer (${size.stringMB})"
+        }
         return ConsumerBuffer(skiaBitmap)
     }
 }

--- a/pdfmp/src/nonAndroidConsumerTest/kotlin/com/dshatz/pdfmp/ViewportBufferLifecycleTest.kt
+++ b/pdfmp/src/nonAndroidConsumerTest/kotlin/com/dshatz/pdfmp/ViewportBufferLifecycleTest.kt
@@ -1,0 +1,98 @@
+package com.dshatz.pdfmp
+
+import com.dshatz.pdfmp.model.PageTransform
+import com.dshatz.pdfmp.model.SizeB
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+
+/**
+ * Regression tests for two viewport-buffer defects that killed apps in the field with
+ * `IllegalStateException: Could not read bitmap buffer address` (and, for the dispose race,
+ * native crashes in SkBitmap::peekPixels):
+ *
+ * 1. [ConsumerBufferUtil.allocate] ignored `allocPixels`' result — a failed allocation (memory
+ *    pressure, oversized viewport at deep zoom) handed out a pixel-less bitmap that only failed
+ *    later, inside a render, with a misleading error.
+ * 2. [ConsumerBufferPool.getBufferViewport] disposed the previous viewport buffer inline when the
+ *    viewport grew, with no coordination with an in-flight render still holding it or with the
+ *    displayed image referencing its pixels zero-copy (extractSubset). Buffers are now retired
+ *    instead and disposed on a later request, once freed by their consumer.
+ */
+val viewportBufferLifecycleTest by testSuite {
+    testFixture {
+        InitLib().init()
+    } asContextForAll {
+        test("allocation failure fails fast with a descriptive error") {
+            // Dimensions whose byte size overflows: Skia rejects the allocation. The failure must
+            // surface here, at the cause — not later as a buffer-address error inside a render.
+            val failure = shouldThrow<IllegalStateException> {
+                ConsumerBufferUtil.allocate(
+                    SizeB(Int.MAX_VALUE.toLong() * Int.MAX_VALUE * 4L),
+                    Int.MAX_VALUE,
+                    Int.MAX_VALUE,
+                )
+            }
+            failure.message shouldStartWith "Failed to allocate"
+        }
+
+        test("growing the viewport keeps the previously handed-out buffer alive") {
+            val pool = ConsumerBufferPool()
+            // Render A acquires the viewport buffer...
+            val heldByRenderA = pool.getBufferViewport(listOf(squareTransform(100)))
+            // ...then the viewport grows (zoom/rotation) while render A still holds it.
+            pool.getBufferViewport(listOf(squareTransform(200)))
+
+            withClue("a buffer still handed out to a render must not be disposed") {
+                heldByRenderA.skiaBitmap.isClosed shouldBe false
+            }
+            heldByRenderA.withAddress {
+                it.toULong() shouldBeGreaterThan 0u
+            }
+            withClue("the replaced buffer is retired until its consumer frees it") {
+                pool.retiredViewportBuffers shouldContainExactly listOf(heldByRenderA)
+            }
+        }
+
+        test("retired viewport buffer is disposed once freed and a later request arrives") {
+            val pool = ConsumerBufferPool()
+            val old = pool.getBufferViewport(listOf(squareTransform(100)))
+            pool.getBufferViewport(listOf(squareTransform(200)))
+
+            // The consumer releases the replaced buffer (PdfViewport frees the previous image)...
+            old.free()
+            // ...and the next pool request sweeps retired buffers: no use-after-free, no leak.
+            pool.getBufferViewport(listOf(squareTransform(200)))
+            withClue("freed retired buffer must be disposed on the next request") {
+                old.skiaBitmap.isClosed shouldBe true
+                pool.retiredViewportBuffers shouldBe emptyList()
+            }
+        }
+
+        test("handed-out viewport buffer is marked unfree") {
+            val pool = ConsumerBufferPool()
+            val buffer = pool.getBufferViewport(listOf(squareTransform(100)))
+            withClue("a handed-out buffer must be marked unfree until released") {
+                buffer.isFree shouldBe false
+            }
+        }
+    }
+}
+
+private fun squareTransform(size: Int): PageTransform {
+    return PageTransform(
+        0,
+        0,
+        0,
+        0,
+        0,
+        size,
+        size,
+        0,
+        1f
+    )
+}


### PR DESCRIPTION
Two defects in the viewport buffer path killed consuming apps in the field (Kotlin/Native turns an uncaught worker exception into process death):

1. ConsumerBufferPool.getBufferViewport disposed the previous viewport buffer inline whenever a larger viewport was requested — with no coordination with an in-flight render still holding it (PdfView renders in a debounced produceState coroutine on Dispatchers.IO, so zoom/rotation restarts it mid-flight) or with the displayed image, which references the buffer's pixels zero-copy via extractSubset. Calling withAddress on the disposed buffer dies natively (SIGABRT in SkBitmap::peekPixels on JVM, SIGSEGV on iOS); the silent variant has the native renderer writing through a dangling pointer. This is likely the root cause of #41 ("recycled bitmap" while zooming on Android — the same race in the Android buffer implementation).

   Replaced buffers are now retired instead of disposed and cleaned up on a later request once their consumer freed them. Handed-out viewport buffers are marked unfree; PdfViewport releases the replaced image (buffer-identity guarded, since same-size requests reuse the instance).

2. ConsumerBufferUtil.allocate ignored allocPixels' Boolean result, so a failed allocation (memory pressure, oversized viewport at deep zoom) handed out a pixel-less bitmap whose peekPixels() returns null — surfacing much later as a misleading "Could not read bitmap buffer address" inside a render. Observed in production via crash reporting on iOS. Allocation failures now fail fast with a descriptive message, and PdfState contains buffer failures into its existing error state (CancellationException rethrown) instead of letting them escape the render coroutine.

New nonAndroidConsumerTest suite covers fail-fast allocation, held- buffer survival on viewport growth, the retire/free/dispose lifecycle, and unfree marking; the existing consumerBufferTest expectation is updated to the new lifecycle. Verified on jvmTest and iosSimulatorArm64Test.